### PR TITLE
Fixes typos at lecture 3.2

### DIFF
--- a/lectures/03.fundamentals.md
+++ b/lectures/03.fundamentals.md
@@ -522,7 +522,7 @@ your allocator, so you have no way to pass / store state in the allocator!
 
 ##### Logging
 
-Having only an error (with an callstack if we are lucky) often is not enough.
+Having only an error (with a callstack if we are lucky) often is not enough.
 
 Logging is essential for understanding what is going on with the program.
 
@@ -628,7 +628,7 @@ examined.
 
 --- VERTICAL SLIDE ---
 
-* poor memory managament
+* poor memory management
 
 --- VERTICAL SLIDE ---
 


### PR DESCRIPTION
Оправя някои правописни грешки в трета презентация.
- an callstack   -> a callstack
- managament -> management
